### PR TITLE
delete just deletes, instead of moving it to trash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/dummy/db/*.sqlite3-journal
 test/dummy/log/*.log
 test/dummy/storage/
 test/dummy/tmp/
+*.gem

--- a/actionmailbox-imap.gemspec
+++ b/actionmailbox-imap.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+    spec.metadata["allowed_push_host"] = "https://rubygems.org"
   else
     raise "RubyGems 2.0 or newer is required to protect against " \
       "public gem pushes."

--- a/lib/actionmailbox/imap/adapters/net_imap.rb
+++ b/lib/actionmailbox/imap/adapters/net_imap.rb
@@ -26,11 +26,6 @@ module ActionMailbox
         end
 
         def delete_message(id)
-          move_message_to(id, "TRASH")
-        end
-
-        def move_message_to(id, mailbox)
-          imap.copy(id, mailbox)
           imap.store(id, "+FLAGS", [:Deleted])
         end
 

--- a/test/actionmailbox/imap/adapters/net_imap_test.rb
+++ b/test/actionmailbox/imap/adapters/net_imap_test.rb
@@ -96,7 +96,6 @@ class ActionMailbox::IMAP::Adapters::NetImap::Test < ActiveSupport::TestCase
   test ".delete_message deletes a message successfully" do
     net_imap = MiniTest::Mock.new
     net_imap.expect :new, net_imap, ["some.server.com", 993, true]
-    net_imap.expect :copy, nil, [1, "TRASH"]
     net_imap.expect :store, nil, [1, "+FLAGS", [:Deleted]]
 
     Net.stub_const :IMAP, net_imap do
@@ -107,25 +106,6 @@ class ActionMailbox::IMAP::Adapters::NetImap::Test < ActiveSupport::TestCase
       )
 
       fake_adapter.delete_message(1)
-
-      net_imap.verify
-    end
-  end
-
-  test ".move_message_to deletes a message successfully" do
-    net_imap = MiniTest::Mock.new
-    net_imap.expect :new, net_imap, ["some.server.com", 993, true]
-    net_imap.expect :copy, nil, [1, "Saved"]
-    net_imap.expect :store, nil, [1, "+FLAGS", [:Deleted]]
-
-    Net.stub_const :IMAP, net_imap do
-      fake_adapter = ActionMailbox::IMAP::Adapters::NetImap.new(
-        server: "some.server.com",
-        port: 993,
-        usessl: true
-      )
-
-      fake_adapter.move_message_to(1, "Saved")
 
       net_imap.verify
     end


### PR DESCRIPTION
Before this PR, when a message was relayed to ActionMailbox, it would first attempt to move it to a "TRASH" mailbox. This was a idea to save emails even after they were relayed and then the server could periodically truncate this mailbox.

I'm not sure if this is right or even needed at the moment.