### PR TITLE
Grab only Unseen emails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    actionmailbox-imap (0.1.0)
+    actionmailbox-imap (0.1.1)
       rails (~> 6.0.0.rc2)
 
 GEM

--- a/lib/actionmailbox/imap/adapters/net_imap.rb
+++ b/lib/actionmailbox/imap/adapters/net_imap.rb
@@ -21,12 +21,20 @@ module ActionMailbox
           imap.disconnect
         end
 
-        def messages_not_deleted
-          imap.search(["NOT", "DELETED"])
+        def messages
+          imap.search(["NOT", "DELETED", "NOT", "SEEN"])
         end
 
         def delete_message(id)
           imap.store(id, "+FLAGS", [:Deleted])
+        end
+
+        def mark_message_seen(id)
+          imap.store(id, "+FLAGS", [:Seen])
+        end
+
+        def mark_message_unseen(id)
+          imap.store(id, "-FLAGS", [:Seen])
         end
 
         def fetch_message_attr(id, attr)

--- a/lib/actionmailbox/imap/mailbox.rb
+++ b/lib/actionmailbox/imap/mailbox.rb
@@ -9,7 +9,7 @@ module ActionMailbox
       end
 
       def messages
-        result = adapter.messages_not_deleted
+        result = adapter.messages
         Messages.new(adapter: adapter, message_ids: result)
       end
 

--- a/lib/actionmailbox/imap/message.rb
+++ b/lib/actionmailbox/imap/message.rb
@@ -16,6 +16,14 @@ module ActionMailbox
         adapter.delete_message(id)
       end
 
+      def mark_read
+        adapter.mark_message_seen(id)
+      end
+
+      def mark_unread
+        adapter.mark_message_unseen(id)
+      end
+
       private
 
       attr_reader :adapter, :id

--- a/lib/actionmailbox/imap/messages.rb
+++ b/lib/actionmailbox/imap/messages.rb
@@ -25,6 +25,18 @@ module ActionMailbox
         end
       end
 
+      def mark_read
+        message_ids.each do |id|
+          adapter.mark_message_seen(id)
+        end
+      end
+
+      def mark_unread
+        message_ids.each do |id|
+          adapter.mark_message_unseen(id)
+        end
+      end
+
       private
 
       attr_reader :adapter, :message_ids

--- a/lib/tasks/actionmailbox/ingress.rake
+++ b/lib/tasks/actionmailbox/ingress.rake
@@ -28,9 +28,14 @@ namespace :action_mailbox do
 
       relayer = ActionMailbox::Relayer.new(url: url, password: password)
 
-      mailbox.messages.take(config[:take]).each do |message|
+      messages = mailbox.messages.take(config[:take])
+
+      messages.mark_read
+
+      messages.each do |message|
         relayer.relay(message.rfc822).tap do |result|
           message.delete if result.success?
+          message.mark_unread unless result.success?
         end
       end
 

--- a/test/actionmailbox/imap/adapters/net_imap_test.rb
+++ b/test/actionmailbox/imap/adapters/net_imap_test.rb
@@ -75,10 +75,10 @@ class ActionMailbox::IMAP::Adapters::NetImap::Test < ActiveSupport::TestCase
     end
   end
 
-  test ".message_not_deleted calls search successfully" do
+  test ".messages calls search successfully" do
     net_imap = MiniTest::Mock.new
     net_imap.expect :new, net_imap, ["some.server.com", 993, true]
-    net_imap.expect :search, [1, 2], [["NOT", "DELETED"]]
+    net_imap.expect :search, [1, 2], [["NOT", "DELETED", "NOT", "SEEN"]]
 
     Net.stub_const :IMAP, net_imap do
       fake_adapter = ActionMailbox::IMAP::Adapters::NetImap.new(
@@ -87,7 +87,7 @@ class ActionMailbox::IMAP::Adapters::NetImap::Test < ActiveSupport::TestCase
         usessl: true
       )
 
-      fake_adapter.messages_not_deleted
+      fake_adapter.messages
 
       net_imap.verify
     end
@@ -106,6 +106,42 @@ class ActionMailbox::IMAP::Adapters::NetImap::Test < ActiveSupport::TestCase
       )
 
       fake_adapter.delete_message(1)
+
+      net_imap.verify
+    end
+  end
+
+  test ".mark_message_seen marks a message as seen" do
+    net_imap = MiniTest::Mock.new
+    net_imap.expect :new, net_imap, ["some.server.com", 993, true]
+    net_imap.expect :store, nil, [1, "+FLAGS", [:Seen]]
+
+    Net.stub_const :IMAP, net_imap do
+      fake_adapter = ActionMailbox::IMAP::Adapters::NetImap.new(
+        server: "some.server.com",
+        port: 993,
+        usessl: true
+      )
+
+      fake_adapter.mark_message_seen(1)
+
+      net_imap.verify
+    end
+  end
+
+  test ".mark_message_unseen marks a message as seen" do
+    net_imap = MiniTest::Mock.new
+    net_imap.expect :new, net_imap, ["some.server.com", 993, true]
+    net_imap.expect :store, nil, [1, "-FLAGS", [:Seen]]
+
+    Net.stub_const :IMAP, net_imap do
+      fake_adapter = ActionMailbox::IMAP::Adapters::NetImap.new(
+        server: "some.server.com",
+        port: 993,
+        usessl: true
+      )
+
+      fake_adapter.mark_message_unseen(1)
 
       net_imap.verify
     end

--- a/test/actionmailbox/imap/mailbox_test.rb
+++ b/test/actionmailbox/imap/mailbox_test.rb
@@ -5,7 +5,7 @@ require "minitest/mock"
 class ActionMailbox::IMAP::Mailbox::Test < ActiveSupport::TestCase
   test ".messages returns Messages successfully" do
     fake_adapter = MiniTest::Mock.new
-    fake_adapter.expect :messages_not_deleted, [1, 2]
+    fake_adapter.expect :messages, [1, 2]
 
     mailbox = ActionMailbox::IMAP::Mailbox.new(adapter: fake_adapter, mailbox: "INBOX")
     result = mailbox.messages

--- a/test/actionmailbox/imap/message_test.rb
+++ b/test/actionmailbox/imap/message_test.rb
@@ -35,14 +35,25 @@ class ActionMailbox::IMAP::Message::Test < ActiveSupport::TestCase
     fake_adapter.verify
   end
 
-  test ".delete returns false when the adapter returns false" do
+  test ".mark_read calls adapter mark_message_seen successfully" do
     fake_adapter = MiniTest::Mock.new
-    fake_adapter.expect :delete_message, false, [1]
+    fake_adapter.expect :mark_message_seen, true, [1]
 
     message = ActionMailbox::IMAP::Message.new(adapter: fake_adapter, id: 1)
-    result = message.delete
+    result = message.mark_read
 
-    assert !result
+    assert result
+    fake_adapter.verify
+  end
+
+  test ".mark_unread calls adapter mark_message_unseen successfully" do
+    fake_adapter = MiniTest::Mock.new
+    fake_adapter.expect :mark_message_unseen, true, [1]
+
+    message = ActionMailbox::IMAP::Message.new(adapter: fake_adapter, id: 1)
+    result = message.mark_unread
+
+    assert result
     fake_adapter.verify
   end
 end

--- a/test/actionmailbox/imap/messages_test.rb
+++ b/test/actionmailbox/imap/messages_test.rb
@@ -14,7 +14,6 @@ class ActionMailbox::IMAP::Messages::Test < ActiveSupport::TestCase
 
   test ".take returns the right number of messages" do
     fake_adapter = MiniTest::Mock.new
-
     messages = ActionMailbox::IMAP::Messages.new(adapter: fake_adapter, message_ids: [1, 2, 3, 4])
     result = messages.take(2)
 
@@ -42,5 +41,33 @@ class ActionMailbox::IMAP::Messages::Test < ActiveSupport::TestCase
     end
 
     assert count == 4
+  end
+
+  test ".mark_read marks all messages as read" do
+    fake_adapter = MiniTest::Mock.new
+
+    messages = ActionMailbox::IMAP::Messages.new(adapter: fake_adapter, message_ids: [1, 2, 3, 4])
+
+    [1, 2, 3, 4].each do |id|
+      fake_adapter.expect :mark_message_seen, nil, [id]
+    end
+
+    messages.mark_read
+
+    fake_adapter.verify
+  end
+
+  test ".mark_unread marks all messages as read" do
+    fake_adapter = MiniTest::Mock.new
+
+    messages = ActionMailbox::IMAP::Messages.new(adapter: fake_adapter, message_ids: [1, 2, 3, 4])
+
+    [1, 2, 3, 4].each do |id|
+      fake_adapter.expect :mark_message_unseen, nil, [id]
+    end
+
+    messages.mark_unread
+
+    fake_adapter.verify
   end
 end

--- a/test/tasks/actionmailbox/ingress_test.rb
+++ b/test/tasks/actionmailbox/ingress_test.rb
@@ -31,7 +31,12 @@ class ActionMailbox::IngressTest < ActiveSupport::TestCase
     net_imap_mock.expect :new, net_imap_mock, [server: "smtp.email.com", port: 993, usessl: true]
     net_imap_mock.expect :login, nil, [username: "some@email.com", password: "smtp_password"]
     net_imap_mock.expect :select_mailbox, nil, ["INBOX"]
-    net_imap_mock.expect :messages_not_deleted, [1, 2, 3]
+
+    fake_message_ids = [1, 2, 3]
+    net_imap_mock.expect :messages_not_deleted, fake_message_ids
+    fake_message_ids.each do |id|
+      net_imap_mock.expect :mark_message_seen, nil, [id]
+    end
 
     net_imap_mock.expect :fetch_message_attr, "message 1", [1, "RFC822"]
     net_imap_mock.expect :fetch_message_attr, "message 2", [2, "RFC822"]
@@ -95,7 +100,11 @@ class ActionMailbox::IngressTest < ActiveSupport::TestCase
     net_imap_mock.expect :new, net_imap_mock, [server: "smtp.email.com", port: 993, usessl: true]
     net_imap_mock.expect :login, nil, [username: "some@email.com", password: "smtp_password"]
     net_imap_mock.expect :select_mailbox, nil, ["INBOX"]
-    net_imap_mock.expect :messages_not_deleted, [1, 2, 3]
+    fake_message_ids = [1, 2, 3]
+    net_imap_mock.expect :messages_not_deleted, fake_message_ids
+    fake_message_ids.each do |id|
+      net_imap_mock.expect :mark_message_seen, nil, [id]
+    end
 
     net_imap_mock.expect :fetch_message_attr, "message 1", [1, "RFC822"]
     net_imap_mock.expect :fetch_message_attr, "message 2", [2, "RFC822"]
@@ -113,8 +122,11 @@ class ActionMailbox::IngressTest < ActiveSupport::TestCase
     end
 
     action_mailbox_relayer_mock.expect :relay, action_mailbox_relayer_result_mock, ["message 1"]
+    net_imap_mock.expect :mark_message_unseen, nil, [1]
     action_mailbox_relayer_mock.expect :relay, action_mailbox_relayer_result_mock, ["message 2"]
+    net_imap_mock.expect :mark_message_unseen, nil, [2]
     action_mailbox_relayer_mock.expect :relay, action_mailbox_relayer_result_mock, ["message 3"]
+    net_imap_mock.expect :mark_message_unseen, nil, [3]
 
     net_imap_mock.expect :disconnect, nil
 

--- a/test/tasks/actionmailbox/ingress_test.rb
+++ b/test/tasks/actionmailbox/ingress_test.rb
@@ -33,7 +33,7 @@ class ActionMailbox::IngressTest < ActiveSupport::TestCase
     net_imap_mock.expect :select_mailbox, nil, ["INBOX"]
 
     fake_message_ids = [1, 2, 3]
-    net_imap_mock.expect :messages_not_deleted, fake_message_ids
+    net_imap_mock.expect :messages, fake_message_ids
     fake_message_ids.each do |id|
       net_imap_mock.expect :mark_message_seen, nil, [id]
     end
@@ -101,7 +101,7 @@ class ActionMailbox::IngressTest < ActiveSupport::TestCase
     net_imap_mock.expect :login, nil, [username: "some@email.com", password: "smtp_password"]
     net_imap_mock.expect :select_mailbox, nil, ["INBOX"]
     fake_message_ids = [1, 2, 3]
-    net_imap_mock.expect :messages_not_deleted, fake_message_ids
+    net_imap_mock.expect :messages, fake_message_ids
     fake_message_ids.each do |id|
       net_imap_mock.expect :mark_message_seen, nil, [id]
     end


### PR DESCRIPTION
In order to prevent a scheduled command that runs while a previous run
is happening from grabbing the same emails, we mark the messages as read
as soon as we grab them. Then if they relay we delete them, but if it
doesn't relay we mark the message as unseen for another try later.