### PR TITLE
Refactor Imap session use

### DIFF
--- a/config/actionmailbox_imap.yaml
+++ b/config/actionmailbox_imap.yaml
@@ -18,3 +18,11 @@ mailbox: "RETRY"
 #
 # DO NOT use more workers than you have threads available.
 workers: 4
+
+# Wait (in ms)
+#
+# Once a server sends the ANY back from waiting
+# for activity, you can wait some time before grabbing
+# messages. This way the client should grab more than
+# just the first message to to trigger activity.
+wait: 800

--- a/lib/generators/imap/templates/config.yml
+++ b/lib/generators/imap/templates/config.yml
@@ -18,3 +18,11 @@ mailbox: "INBOX"
 #
 # DO NOT use more workers than you have threads available.
 workers: 4
+
+# Wait (in ms)
+#
+# Once a server sends the ANY back from waiting
+# for activity, you can wait some time before grabbing
+# messages. This way the client should grab more than
+# just the first message to to trigger activity.
+wait: 800

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -10,6 +10,7 @@ pub struct Configuration {
     password: String,
     mailbox: String,
     workers: usize,
+    wait: u64,
 }
 
 impl Configuration {
@@ -47,5 +48,9 @@ impl Configuration {
 
     pub fn workers(&self) -> usize {
         self.workers
+    }
+
+    pub fn wait(&self) -> u64 {
+        self.wait
     }
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -2,7 +2,7 @@ use config::{Config, ConfigError, File};
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]
-pub struct ConfigObject {
+pub struct Configuration {
     server: String,
     port: i64,
     tls: bool,
@@ -12,13 +12,13 @@ pub struct ConfigObject {
     workers: usize,
 }
 
-impl ConfigObject {
-    pub fn new(filename: &str) -> Result<ConfigObject, ConfigError> {
+impl Configuration {
+    pub fn new(filename: &str) -> Result<Configuration, ConfigError> {
         let mut config = Config::new();
 
         config.merge(File::with_name(filename))?;
 
-        config.try_into::<ConfigObject>()
+        config.try_into::<Configuration>()
     }
 
     pub fn server(&self) -> &String {

--- a/src/imap_client.rs
+++ b/src/imap_client.rs
@@ -1,4 +1,4 @@
-use crate::configuration::ConfigObject;
+use crate::configuration::Configuration;
 use imap::error::Error;
 use std::net::TcpStream;
 
@@ -6,11 +6,11 @@ type ImapClientType = imap::Client<native_tls::TlsStream<TcpStream>>;
 
 pub struct ImapClient<'a> {
     client: ImapClientType,
-    config: &'a ConfigObject,
+    config: &'a Configuration,
 }
 
 impl<'a> ImapClient<'a> {
-    pub fn new(config: &'a ConfigObject) -> Result<Self, Error> {
+    pub fn new(config: &'a Configuration) -> Result<Self, Error> {
         let tls = native_tls::TlsConnector::builder().build()?;
 
         let client = imap::connect(

--- a/src/imap_session.rs
+++ b/src/imap_session.rs
@@ -29,7 +29,7 @@ impl<'a, 's> ImapSession<'a, 's> {
 
         println!("Activity detected.");
 
-        std::thread::sleep(std::time::Duration::from_millis(800));
+        std::thread::sleep(std::time::Duration::from_millis(self.config.wait()));
 
         println!("Grabbing new messages from mailbox.");
 

--- a/src/imap_session.rs
+++ b/src/imap_session.rs
@@ -1,0 +1,81 @@
+use crate::configuration::Configuration;
+
+use std::net::TcpStream;
+
+type ImapSessionType<'s> = &'s mut imap::Session<native_tls::TlsStream<TcpStream>>;
+
+pub struct ImapSession<'a, 's> {
+    session: ImapSessionType<'s>,
+    config: &'a Configuration,
+}
+
+impl<'a, 's> ImapSession<'a, 's> {
+    pub fn from(config: &'a Configuration, session: ImapSessionType<'s>) -> Self {
+        ImapSession { session, config }
+    }
+
+    pub fn select_mailbox(&mut self) -> imap::error::Result<imap::types::Mailbox> {
+        self.session.select(self.config.mailbox())
+    }
+
+    pub fn wait_for_messages(
+        &mut self,
+    ) -> imap::error::Result<std::collections::HashSet<imap::types::Seq>> {
+        let idle = self.session.idle()?;
+
+        println!("Begin listening for activity on IMAP server.");
+
+        idle.wait_keepalive()?;
+
+        println!("Activity detected.");
+
+        std::thread::sleep(std::time::Duration::from_millis(800));
+
+        println!("Grabbing new messages from mailbox.");
+
+        self.session.search("NOT DELETED NOT SEEN")
+    }
+
+    pub fn mark_message_read(
+        &mut self,
+        id: u32,
+    ) -> imap::error::Result<imap::types::ZeroCopy<Vec<imap::types::Fetch>>> {
+        self.session.store(format!("{}", id), "+FLAGS (\\Seen)")
+    }
+
+    pub fn mark_message_unread(
+        &mut self,
+        id: u32,
+    ) -> imap::error::Result<imap::types::ZeroCopy<Vec<imap::types::Fetch>>> {
+        self.session.store(format!("{}", id), "-flags (\\Seen)")
+    }
+
+    pub fn mark_message_deleted(
+        &mut self,
+        id: u32,
+    ) -> imap::error::Result<imap::types::ZeroCopy<Vec<imap::types::Fetch>>> {
+        self.session.store(format!("{}", id), "+FLAGS (\\Deleted)")
+    }
+    pub fn get_message_body(&mut self, id: u32) -> Option<Vec<u8>> {
+        let messages = match self.session.fetch(format!("{}", id), "RFC822") {
+            Ok(messages) => messages,
+            Err(_) => return None,
+        };
+
+        let message = match messages.iter().next() {
+            Some(message) => message,
+            None => return None,
+        };
+
+        let body: Vec<u8> = message.body().unwrap().iter().cloned().collect::<Vec<u8>>();
+        Some(body)
+    }
+
+    pub fn expunge(&mut self) -> imap::error::Result<Vec<imap::types::Seq>> {
+        self.session.expunge()
+    }
+
+    pub fn logout(&mut self) -> imap::error::Result<()> {
+        self.session.logout()
+    }
+}


### PR DESCRIPTION
I brought `imap::Session` use into its own struct, and a couple methods to encapsulate any sequential calls. 

I'm not sure if this is better or just more or different.